### PR TITLE
[TESTS] Add global random seed for deterministic test

### DIFF
--- a/tests/structures/graphs/conftest.py
+++ b/tests/structures/graphs/conftest.py
@@ -12,6 +12,11 @@ from tests.helpers.utils import generate_unique_upper_names
 MAX_WEIGHT = 1000
 
 
+def pytest_sessionstart(session):
+    """Initialize a fixed global random seed for the test session."""
+    random.seed(17)
+
+
 @pytest.fixture(
     scope="module",
     params=[

--- a/tests/structures/graphs/conftest.py
+++ b/tests/structures/graphs/conftest.py
@@ -1,5 +1,5 @@
 from math import ceil, sqrt
-from random import choices, randint
+from random import choices, randint, seed
 from typing import Any, Dict, List, Set, Tuple, Type, Union
 
 import pytest
@@ -14,7 +14,7 @@ MAX_WEIGHT = 1000
 
 def pytest_sessionstart(session):
     """Initialize a fixed global random seed for the test session."""
-    random.seed(17)
+    seed(17)
 
 
 @pytest.fixture(


### PR DESCRIPTION
## Description

This PR sets a fixed global random seed for each pytest session to make tests deterministic and easier to debug.

## Motivation

Some tests rely on randomness without an explicit seed, which can lead to non-deterministic behavior and make failures harder to reproduce, especially in CI environments.

## Change

A global random seed is initialized at the start of each pytest session to ensure consistent behavior across test runs.

## Benefits

- Reproducible test results  
- Easier debugging of failures  
- More consistent CI behavior  

The issue was identified during an ongoing research project.